### PR TITLE
fix: prevent inactive validators send message

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -342,8 +342,9 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 
 			newRound := currentRound + 1
 			i.moveToNewRound(newRound)
-
-			i.sendRoundChangeMessage(h, newRound)
+			if i.backend.IsActiveValidatorSubset() {
+				i.sendRoundChangeMessage(h, newRound)
+			}
 		case <-i.roundDone:
 			// The consensus cycle for the block height is finished.
 			// Stop all running worker threads

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -341,8 +341,8 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 			i.log.Info("round timeout expired", "round", currentRound)
 
 			newRound := currentRound + 1
-			i.moveToNewRound(newRound)
 			if i.backend.IsActiveValidatorSubset() {
+				i.moveToNewRound(newRound)
 				i.sendRoundChangeMessage(h, newRound)
 			}
 		case <-i.roundDone:


### PR DESCRIPTION
Because inactive validators can still send round change message so it may lead to some logging errors like this so we have to filter them
![image](https://user-images.githubusercontent.com/51268460/232429156-a7682d8b-22cb-4417-b65c-1665ae1537b0.png)
